### PR TITLE
Force OSI topics to render as one list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1873,7 +1873,6 @@ You can read more about the OSI model in [penguintutor.com](http://www.penguintu
   * IP address
   * Terminate connections
   * 3 way handshake</summary><br><b>
-
   * Error correction
   * Packets routing - Network
   * Cables and electrical signals - Physical


### PR DESCRIPTION
Fixes #91 

Simple one-line removal that makes the list render normally. Screenshot for reference:
![image](https://user-images.githubusercontent.com/13409103/87862978-0cdc6f00-c924-11ea-8a23-375272fc8901.png)

There is also an empty "details" toggle under this question, but perhaps that can be an issue (that way this commit is just about the OSI question).