### PR TITLE
Fix requirement typo

### DIFF
--- a/topics/terraform/exercises/launch_ec2_instance/exercise.md
+++ b/topics/terraform/exercises/launch_ec2_instance/exercise.md
@@ -1,6 +1,6 @@
 # Launch EC2 instance
 
-## Reuqirements
+## Requirements
 
 * AWS account
 

--- a/topics/terraform/exercises/launch_ec2_instance/solution.md
+++ b/topics/terraform/exercises/launch_ec2_instance/solution.md
@@ -1,6 +1,6 @@
 # Launch EC2 instance
 
-## Reuqirements
+## Requirements
 
 * AWS account
 


### PR DESCRIPTION
There was a typo in your Terraform exercises.

modified files: 
launch_ec2_instance/exercise.md
aunch_ec2_instance/solution.md