### PR TITLE
Use Kubectl command instead of kustomize

### DIFF
--- a/topics/kubernetes/exercises/kustomize_common_labels/solution.md
+++ b/topics/kubernetes/exercises/kustomize_common_labels/solution.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 1. Running Kubernetes cluster
-2. Kustomize binary installed
+2. Kubctl version 1.14 or above
 
 ## Objectives
 
@@ -28,4 +28,4 @@ resources:
   - deployment.yml
 ```
 
-2. Run `kustomize build someApp`
+2. Run `kubectl apply -k someApp`


### PR DESCRIPTION
Since 1.14, Kubectl also supports the management of Kubernetes objects using a kustomization file. cf. https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays