### PR TITLE
Removed the need for Kustomize in prerequisites

### DIFF
--- a/topics/kubernetes/exercises/kustomize_common_labels/exercise.md
+++ b/topics/kubernetes/exercises/kustomize_common_labels/exercise.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 1. Running Kubernetes cluster
-2. Kustomize binary installed
+2. Kubctl version 1.14 or above
 
 ## Objectives
 


### PR DESCRIPTION
Since 1.14, Kubectl also supports the management of Kubernetes objects using a kustomization file. cf. https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays