### PR TITLE
Aws certification paths

### DIFF
--- a/certificates/aws-certification-paths.md
+++ b/certificates/aws-certification-paths.md
@@ -1,0 +1,3 @@
+## AWS Certification Paths
+
+(AWS Certification Paths based on Cloud Roles and Responsibilities)[https://d1.awsstatic.com/training-and-certification/docs/AWS_certification_paths.pdf]

--- a/certificates/aws-certification-paths.md
+++ b/certificates/aws-certification-paths.md
@@ -1,3 +1,3 @@
 ## AWS Certification Paths
 
-(AWS Certification Paths based on Cloud Roles and Responsibilities)[https://d1.awsstatic.com/training-and-certification/docs/AWS_certification_paths.pdf]
+[AWS Certification Paths based on Cloud Roles and Responsibilities](https://d1.awsstatic.com/training-and-certification/docs/AWS_certification_paths.pdf)


### PR DESCRIPTION
added a AWS Certification Paths doc for developers to navigate AWS Certifications based on particular roles and responsibilities.
@bregman-arie kindly review, thanks.