### PR TITLE
Corrects the solution for linux copy exercise

### DIFF
--- a/topics/linux/exercises/copy/solution.md
+++ b/topics/linux/exercises/copy/solution.md
@@ -17,8 +17,7 @@ touch /tmp/x
 cp x ~/
 cp x y
 mkdir files
-cp x files
-cp y files
+mv x files | mv y files
 cp -r files copy_of_files
 mv copy_of_files files2
 rm -rf files files2


### PR DESCRIPTION
Fixes the solution of the copy exercise with regards to step 4. Originally it did not move x and y to the files directory, but instead, it copied them to files.