### PR TITLE
Added Solution for AWS - Launch EC2 Web Instance Using Terraform

### DIFF
--- a/topics/aws/exercises/launch_ec2_web_instance/solution.md
+++ b/topics/aws/exercises/launch_ec2_web_instance/solution.md
@@ -37,3 +37,58 @@ echo "<h1>I made it! This is is awesome!</h1>" > /var/www/html/index.html
 9. In the security group section, add a rule to accept HTTP traffic (TCP) on port 80 from anywhere
 10. Click on "Review" and then click on "Launch" after reviewing.
 11. If you don't have a key pair, create one and download it.
+
+12. ### Solution using Terraform
+
+```
+ 
+provider "aws" {
+  region = "us-east-1" // Or your desired region
+}
+
+resource "aws_instance" "web_server" {
+  ami           = "ami-12345678" // Replace with the correct AMI for Amazon Linux 2
+  instance_type = "t2.micro" // Or any instance type with 1 vCPU and 1 GiB memory
+
+  tags = {
+    Name = "web-1"
+    Type = "web"
+  }
+
+  root_block_device {
+    volume_size           = 8 // Or any desired size
+    delete_on_termination = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo yum update -y",
+      "sudo yum install -y httpd",
+      "sudo systemctl start httpd",
+      "sudo bash -c 'echo \"I made it! This is awesome!\" > /var/www/html/index.html'",
+      "sudo systemctl enable httpd"
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = file("~/.ssh/your_private_key.pem") // Replace with the path to your private key
+      host        = self.public_ip
+    }
+  }
+
+  security_group_ids = [aws_security_group.web_sg.id]
+}
+
+resource "aws_security_group" "web_sg" {
+  name        = "web_sg"
+  description = "Security group for web server"
+  
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+```


### PR DESCRIPTION
This pull request adds Terraform configuration files to launch an EC2 instance on AWS with specific requirements:

Launches an Amazon Linux 2 instance with 1 vCPU and 1 GiB memory.
Deletes the instance storage upon termination.
Installs and starts the Apache HTTP Server (httpd) on the instance.
Sets the content of /var/www/html/index.html to "I made it! This is awesome!".
Tags the instance with "Type: web" and names it "web-1".
Allows HTTP traffic (port 80) from anywhere through a configured security group.
This configuration is useful for quickly provisioning a basic web server on AWS using Terraform.