### PR TITLE
[issue  #364] Adjusting URL for AWS Cloud Practitioner exam

### DIFF
--- a/certificates/aws-cloud-practitioner.md
+++ b/certificates/aws-cloud-practitioner.md
@@ -1,6 +1,6 @@
 ## AWS - Cloud Practitioner
 
-A summary of what you need to know for the exam can be found [here](https://codingshell.com/aws-cloud-practitioner)
+A summary of what you need to know for the exam can be found [here](https://aws.amazon.com/certification/certified-cloud-practitioner/)
 
 #### Cloud 101
 


### PR DESCRIPTION
According to the issue below, the link is redirecting to URL that presents a 404 error. Based on that, I am proposing the URL change, pointing directly to AWS URL related to this certification: https://aws.amazon.com/certification/certified-cloud-practitioner/