### PR TITLE
Add required provider block to the terrafom local exercise

### DIFF
--- a/topics/terraform/exercises/terraform_local_provider/exercise.md
+++ b/topics/terraform/exercises/terraform_local_provider/exercise.md
@@ -8,6 +8,15 @@ Learn how to use and run Terraform basic commands
 2. Inside the directory create a file called "main.tf" with the following content
 
 ```terraform
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
 resource "local_file" "mario_local_file" {
     content  = "It's a me, Mario!"
     filename = "/tmp/who_is_it.txt"

--- a/topics/terraform/exercises/terraform_local_provider/solution.md
+++ b/topics/terraform/exercises/terraform_local_provider/solution.md
@@ -8,6 +8,15 @@ Learn how to use and run Terraform basic commands
 2. Inside the directory create a file called "main.tf" with the following content
 
 ```terraform
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
 resource "local_file" "mario_local_file" {
     content  = "It's a me, Mario!"
     filename = "/tmp/who_is_it.txt"
@@ -25,6 +34,15 @@ mkdir my_first_run && cd my_first_run
 
 # Create the file 'main.tf'
 cat << EOT >>  main.tf
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
 resource "local_file" "mario_local_file" {
     content  = "It's a me, Mario!"
     filename = "/tmp/who_is_it.txt"


### PR DESCRIPTION
This pull request addresses the issue [here](https://github.com/bregman-arie/devops-exercises/issues/10547) in the Terraform exercise where the main.tf file is missing a required_providers block. Without this block, running terraform init results in the following error:

```
Error: Invalid provider registry host
The host "registry.terraform.io" given in provider source address "registry.terraform.io/hashicorp/local" does not offer a
Terraform provider registry.
```
The fix adds a terraform block with the required provider details, ensuring compatibility with Terraform 0.13 and later versions.
