### PR TITLE
Broken PR build fix

### DIFF
--- a/scripts/aws s3 event triggering/s3-lambda/s3-lambda.py
+++ b/scripts/aws s3 event triggering/s3-lambda/s3-lambda.py
@@ -1,38 +1,38 @@
 import boto3
 import json
 
+
 def lambda_handler(event, context):
+    # i want to know that event thing
+    print(event)
 
-  # i want to know that event thing
-  print(event)
+    # extract relevant information from the s3 event trigger
+    bucket_name = event['Records'][0]['s3']['bucket']['name']
+    object_key = event['Records'][0]['s3']['object']['key']
 
-  # extract relevant information from the s3 event trigger
-  bucket_name=event['Records'][0]['s3']['bucket']['name']
-  object_key=event['Records'][0]['s3']['object']['key']
+    # perform desired operations with the uploaded file
+    print(f"File '{object_key}' was uploaded to bucket '{bucket_name}'")
 
-  # perform desired operations with the upload file
-  print(f"File '{object_key}' was uploaded to bucket '{bucket_name}'")
+    # example: send a notification via SNS
+    sns_client = boto3.client('sns')
+    topic_arn = 'arn:aws:sns:us-east-1:<account-id>:s3-lambda-sns'
+    sns_client.publish(
+        TopicArn=topic_arn,
+        Subject='s3 object created !!',
+        Message=f"File '{object_key}' was uploaded to bucket '{bucket_name}'"
+    )
 
-  # example: send a notification via sns
-  sns_client=boto3.client('sns')
-  topic_arn='arn:aws:sns:us-east-1:<account-id>:s3-lambda-sns'
-  sns_client.publish(
-    TopicArn=topic_arn,
-    Subject='s3 object created !!',
-    Message=f"File '{object_key}' was uploaded to bucket '{bucket_name}"
-  )
+    # Example: Trigger another Lambda function
+    # lambda_client = boto3.client('lambda')
+    # target_function_name = 'my-another-lambda-function'
+    # lambda_client.invoke(
+    #     FunctionName=target_function_name,
+    #     InvocationType='Event',
+    #     Payload=json.dumps({'bucket_name': bucket_name, 'object_key': object_key})
+    # )
+    # in case of queuing and other objectives similar to the Netflix flow of triggering
 
-  # Example: Trigger another Lambda function
-  # lambda_client = boto3.client('lambda')
-  # target_function_name = 'my-another-lambda-function'
-  # lambda_client.invoke(
-  #    FunctionName=target_function_name,
-  #    InvocationType='Event',
-  #    Payload=json.dumps({'bucket_name': bucket_name, 'object_key': object_key})
-  # )
-  # in case of queuing and other objective similar to the netflix flow of triggering
-
-  return {
-    'statusCode': 200,
-    'body': json.dumps("Lambda function executed successfully !!")
-  }
+    return {
+        'statusCode': 200,
+        'body': json.dumps("Lambda function executed successfully !!")
+    }

--- a/scripts/run_ci.sh
+++ b/scripts/run_ci.sh
@@ -2,12 +2,16 @@
 
 set -euo pipefail
 
-PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/.."
+PROJECT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
 
-MD_FILES=$(find ${PROJECT_DIR} -name "*.md" -not -path "${PROJECT_DIR}/tests/*")
-
-for file in ${MD_FILES[@]}; do
-   python ${PROJECT_DIR}/tests/syntax_lint.py ${file} > /dev/null
+# Use the `-print0` option to handle spaces safely, and while-read loop:
+find "${PROJECT_DIR}" \
+  -name "*.md" \
+  -not -path "${PROJECT_DIR}/tests/*" \
+  -print0 |
+while IFS= read -r -d '' file
+do
+  python "${PROJECT_DIR}/tests/syntax_lint.py" "${file}" > /dev/null
 done
 
 echo "- Syntax lint tests on MD files passed successfully"


### PR DESCRIPTION
- The PR build broke because the folder `aws s3 event triggering` contains spaces.  
- The script used `find` without quoting paths, causing shell word-splitting on spaces.  
- As a result, the python script tried to open `scripts/aws` instead of the full path.  
- Now proper quoting (and `-print0`) ensures the entire path is treated as one argument, even if it has spaces.